### PR TITLE
Allow users to opt-out of changing instance name tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Once you have your ASG set up, you can just invoke this module and point to it:
 module "clever_name_autoscale_dns" {
   source  = "meltwater/asg-dns-handler/aws"
   version = "x.y.z"
+
   # use_public_ip = true
+  # update_instance_name_tag = false
+
   autoscale_handler_unique_identifier = "clever_name"
   autoscale_route53zone_arn           = "ABCDEFGHIJ123"
   vpc_name                            = "my_vpc"

--- a/lambda/autoscale/autoscale.py
+++ b/lambda/autoscale/autoscale.py
@@ -125,7 +125,8 @@ def process_message(message):
     if operation == "UPSERT":
         ip = fetch_ip_from_ec2(instance_id)
 
-        update_name_tag(instance_id, hostname)
+        if os.getenv("update_instance_name_tag", "true") == "true":
+            update_name_tag(instance_id, hostname)
     else:
         ip = fetch_ip_from_route53(hostname, zone_id)
 

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,8 @@ resource "aws_lambda_function" "autoscale_handling" {
   description      = "Handles DNS for autoscaling groups by receiving autoscaling notifications and setting/deleting records from route53"
   environment {
     variables = {
-      "use_public_ip" = var.use_public_ip
+      "use_public_ip" = var.use_public_ip,
+      "update_instance_name_tag" = var.update_instance_name_tag
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "use_public_ip" {
   default     = false
 }
 
+variable "update_instance_name_tag" {
+  description = "Update the name tag of the instance"
+  default     = true
+}
+
 variable "autoscale_route53zone_arn" {
   description = "The ARN of route53 zone associated with autoscaling group"
 }


### PR DESCRIPTION
I was very surprised when my instance names changed after adding this. I much prefer their original names, so I added a way to opt-out of of them being change. 😄 