### PR TITLE
Support for multiple DNS zones

### DIFF
--- a/lambda/autoscale/autoscale.py
+++ b/lambda/autoscale/autoscale.py
@@ -11,7 +11,7 @@ autoscaling = boto3.client('autoscaling')
 ec2 = boto3.client('ec2')
 route53 = boto3.client('route53')
 
-HOSTNAME_TAG_NAME = "asg:hostname_pattern"
+HOSTNAME_TAG_NAME = os.environ['hostname_tag_name']
 
 LIFECYCLE_KEY = "LifecycleHookName"
 ASG_KEY = "AutoScalingGroupName"

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,8 @@ resource "aws_lambda_function" "autoscale_handling" {
   description      = "Handles DNS for autoscaling groups by receiving autoscaling notifications and setting/deleting records from route53"
   environment {
     variables = {
-      "use_public_ip" = var.use_public_ip
+      "use_public_ip" = var.use_public_ip,
+      "hostname_tag_name" = var.hostname_tag_name
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,7 @@ variable "autoscale_route53zone_arn" {
   description = "The ARN of route53 zone associated with autoscaling group"
 }
 
+variable "hostname_tag_name" {
+  description = "Name of tag with hostname pattern"
+  default     = "asg:hostname_pattern"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,4 +18,5 @@ variable "autoscale_route53zone_arn" {
 variable "hostname_tag_name" {
   description = "Name of tag with hostname pattern"
   default     = "asg:hostname_pattern"
+  type        = string
 }


### PR DESCRIPTION
## Proposed Changes

1. Update the `variables.tf` to include a new `hostname_tag_name` variable.
2. Modify `main.tf` to read `hostname_tag_name` from the variables instead of hardcoding it.
3. In `autoscale.py`, change the `HOSTNAME_TAG_NAME` to read from the `os.environ` variables.
4. Expand the `README.md` with a new section explaining how to use the module with multiple DNS zones.
5. Updates to support simultaneous updating of both private and public DNS zones.

### Description

I have made updates to the `terraform-aws-asg-dns-handler` project to add support for multiple DNS zones. This includes changes in the Terraform files and Python script, as well as a comprehensive example and explanation added to the `README.md` file.

### Checklist

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [x] Improve and update the [README](README.md) (if necessary).
