### PR TITLE
54_ttl - allow users to set TTL on DNS Records

### DIFF
--- a/lambda/autoscale/autoscale.py
+++ b/lambda/autoscale/autoscale.py
@@ -20,7 +20,7 @@ ASG_KEY = "AutoScalingGroupName"
 def fetch_ip_from_ec2(instance_id):
     logger.info("Fetching IP for instance-id: %s", instance_id)
     ec2_response = ec2.describe_instances(InstanceIds=[instance_id])
-    if 'use_public_ip' in os.environ and os.environ['use_public_ip'] == "true":
+    if 'USE_PUBLIC_IP' in os.environ and os.environ['USE_PUBLIC_IP'] == "true":
         ip_address = ec2_response['Reservations'][0]['Instances'][0]['PublicIpAddress']
         logger.info("Found public IP for instance-id %s: %s", instance_id, ip_address)
     else:
@@ -93,7 +93,7 @@ def update_record(zone_id, ip, hostname, operation):
                     'ResourceRecordSet': {
                         'Name': hostname,
                         'Type': 'A',
-                        'TTL': 300,
+                        'TTL': os.environ['ROUTE53_TTL'],
                         'ResourceRecords': [{'Value': ip}]
                     }
                 }

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,8 @@ resource "aws_lambda_function" "autoscale_handling" {
   description      = "Handles DNS for autoscaling groups by receiving autoscaling notifications and setting/deleting records from route53"
   environment {
     variables = {
-      "use_public_ip" = var.use_public_ip
+      "USE_PUBLIC_IP" = var.use_public_ip
+      "ROUTE53_TTL"   = var.route53_record_ttl
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,26 @@
 variable "autoscale_handler_unique_identifier" {
   description = "asg_dns_handler"
+  type        = string
 }
 
 variable "vpc_name" {
   description = "The name of the VPC"
+  type        = string
 }
 
 variable "use_public_ip" {
   description = "Use public IP instead of private"
   default     = false
+  type        = bool
 }
 
 variable "autoscale_route53zone_arn" {
   description = "The ARN of route53 zone associated with autoscaling group"
+  type        = string
 }
 
+variable "route53_record_ttl" {
+  description = "TTL to use for the Route 53 Records created"
+  default     = 300
+  type        = number
+}


### PR DESCRIPTION
Fixes #54

## Proposed Changes
- Adds a new variable to the Terraform module `route53_record_ttl` (defaults to `300`) that is passed via Environment Variable to `autoscale.py`

### Description

Allows users to specify a custom DNS (Route53) TTL for the record(s) created for the Autoscaling Handler

### Checklist

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [-] Add tests to cover changes.
- [x] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).

