### PR TITLE
fix: AWS parsing env vars as string, forcing int

### DIFF
--- a/lambda/autoscale/autoscale.py
+++ b/lambda/autoscale/autoscale.py
@@ -93,7 +93,7 @@ def update_record(zone_id, ip, hostname, operation):
                     'ResourceRecordSet': {
                         'Name': hostname,
                         'Type': 'A',
-                        'TTL': os.environ['ROUTE53_TTL'],
+                        'TTL': int(os.environ['ROUTE53_TTL']),
                         'ResourceRecords': [{'Value': ip}]
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/meltwater/terraform-aws-asg-dns-handler/issues/58
Somehow AWS suddenly changed the type of the env var despite being defined in https://github.com/meltwater/terraform-aws-asg-dns-handler/blob/master/variables.tf#L22-L26 as number.

@meltwater-ateam  Please consider merging this bugfix.

```
ERROR] ParamValidationError: Parameter validation failed:
Invalid type for parameter ChangeBatch.Changes[0].ResourceRecordSet.TTL, value: 300, type: <class 'str'>, valid types: <class 'int'>
Traceback (most recent call last):
  File "/var/task/autoscale.py", line 144, in lambda_handler
    process_record(record)
  File "/var/task/autoscale.py", line 136, in process_record
    process_message(json.loads(record['Sns']['Message']))
  File "/var/task/autoscale.py", line 132, in process_message
    update_record(zone_id, ip, hostname, operation)
  File "/var/task/autoscale.py", line 87, in update_record
    route53.change_resource_record_sets(
  File "/var/runtime/botocore/client.py", line 530, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/runtime/botocore/client.py", line 919, in _make_api_call
    request_dict = self._convert_to_request_dict(
  File "/var/runtime/botocore/client.py", line 990, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
  File "/var/runtime/botocore/validate.py", line 381, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
```