### PR TITLE
[INF-8784] mongodb-asg-dns - update runtime version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -110,7 +110,7 @@ resource "aws_lambda_function" "autoscale_handling" {
   function_name    = "${var.vpc_name}-${var.autoscale_handler_unique_identifier}"
   role             = aws_iam_role.autoscale_handling.arn
   handler          = "autoscale.lambda_handler"
-  runtime          = "python3.8"
+  runtime          = "python3.14"
   source_code_hash = filebase64sha256(data.archive_file.autoscale.output_path)
   description      = "Handles DNS for autoscaling groups by receiving autoscaling notifications and setting/deleting records from route53"
   environment {


### PR DESCRIPTION
**Problem:** The lambda runtime version is deprecated

**Solution:** Update the lambda runtime version